### PR TITLE
Hotfix: Corrected behavior regarding braille symbols to be ignored and also lost letters following braille symbols to be ignored.

### DIFF
--- a/src/utils/translator/brailleTranslator.js
+++ b/src/utils/translator/brailleTranslator.js
@@ -19,7 +19,7 @@ export default function brailleTranslator(braillePhrase) {
         let newChar // undefined
 
         if (isIgnoreSymbol(currentBrailleChar)) {
-            newPhrase += currentBrailleChar
+            // newPhrase += currentBrailleChar // why add braile symbols when ignored?
             continue
         }
 
@@ -37,8 +37,8 @@ export default function brailleTranslator(braillePhrase) {
             const doubleSymbols = currentBrailleChar + nextChar
 
             if (isIgnoreSymbol(doubleSymbols)) {
-                newPhrase += doubleSymbols
-                i += 2 
+                //newPhrase += doubleSymbols // why add braile symbols when ignored?
+                i += 1
                 continue
             }
 
@@ -47,7 +47,7 @@ export default function brailleTranslator(braillePhrase) {
 
             if (newChar) {
                 newPhrase += newChar
-                i += 2  
+                i += 1  
                 continue
             }
         }


### PR DESCRIPTION
Denna lösning fixar två stycken problem som funnits i tidigare versioner:

1. Det finns ett register av symboler som ska ignoreras när de förekommer, exempelvis tecknet för kursiv text: ⠠⠄. Förut så lades denna symbol till i den synliga texten av någon anledning, så i denna lösning så tas detta bort (är ganska nyfiken på att veta om det fanns någon anledning till att det fungerade som det gjorde).
2. När en braille-symbol bestod av två symboler, exempelvis för kursiv text: ⠠⠄, så "hoppade" indexen i for-loopen fram två steg, istället för bara ett. Det har lett till att den första bokstaven efter tecknen som skulle ignorerats försvunnit (är åter nyfiken på om det fanns någon anledning till att det fungerade som det gjorde, eller om det bara var en liten miss).